### PR TITLE
Updated namespace for Classic Email template

### DIFF
--- a/unpackaged/post/12_appointment_scheduler_automation/email/rio_ed__RIO_Education/RIO_Education_Appointment_new_appointment.email
+++ b/unpackaged/post/12_appointment_scheduler_automation/email/rio_ed__RIO_Education/RIO_Education_Appointment_new_appointment.email
@@ -1,11 +1,11 @@
-<p>Hi {!Contact_Attendance__c.Contact_Name__c},</p>
+<p>Hi {!rio_ed__Contact_Attendance__c.rio_ed__Contact_Name__c},</p>
 
 <p>
 You have been invited to a new appointment:<br>
-{!Contact_Attendance__c.Booking_Display_Name__c}<br>
-Start: {!Contact_Attendance__c.Booking_Start__c}<br>
-End: {!Contact_Attendance__c.Booking_End__c}<br>
+{!rio_ed__Contact_Attendance__c.rio_ed__Booking_Display_Name__c}<br>
+Start: {!rio_ed__Contact_Attendance__c.rio_ed__Booking_Start__c}<br>
+End: {!rio_ed__Contact_Attendance__c.rio_ed__Booking_End__c}<br>
 </p>
 <p>
-Go here: https://YourCommunity.na124.force.com/portal/s/YourAppointmentSchedulerPage?c__apptId={!Contact_Attendance__c.BookingId__c} to confirm the appointment.
+Go here: https://YourCommunity.na124.force.com/portal/s/YourAppointmentSchedulerPage?c__apptId={!rio_ed__Contact_Attendance__c.rio_ed__Booking__c} to confirm the appointment.
 </p>

--- a/unpackaged/post/12_appointment_scheduler_automation/email/rio_ed__RIO_Education/RIO_Education_Appointment_new_appointment.email-meta.xml
+++ b/unpackaged/post/12_appointment_scheduler_automation/email/rio_ed__RIO_Education/RIO_Education_Appointment_new_appointment.email-meta.xml
@@ -5,14 +5,14 @@
     <name>RIO Education Appointment new appointment</name>
     <style>none</style>
     <subject>New Appointment</subject>
-    <textOnly>Hi {!Contact_Attendance__c.Contact_Name__c},
+    <textOnly>Hi {!rio_ed__Contact_Attendance__c.rio_ed__Contact_Name__c},
 
 You have been invited to a new appointment:
-{!Contact_Attendance__c.Booking_Display_Name__c}
-Start: {!Contact_Attendance__c.Booking_Start__c}
-End: {!Contact_Attendance__c.Booking_End__c}
+{!rio_ed__Contact_Attendance__c.rio_ed__Booking_Display_Name__c}
+Start: {!rio_ed__Contact_Attendance__c.rio_ed__Booking_Start__c}
+End: {!rio_ed__Contact_Attendance__c.rio_ed__Booking_End__c}
 
-Go here:https://YourCommunity.na124.force.com/portal/s/YourAppointmentSchedulerPage?c__apptId={!Contact_Attendance__c.BookingId__c} to confirm the appointment.</textOnly>
+Go here:https://YourCommunity.na124.force.com/portal/s/YourAppointmentSchedulerPage?c__apptId={!rio_ed__Contact_Attendance__c.rio_ed__Booking__c} to confirm the appointment.</textOnly>
     <type>custom</type>
     <uiType>Aloha</uiType>
 </EmailTemplate>

--- a/unpackaged/post/12_appointment_scheduler_automation/email/rio_ed__RIO_Education/RIO_Education_Appointment_status_updated.email
+++ b/unpackaged/post/12_appointment_scheduler_automation/email/rio_ed__RIO_Education/RIO_Education_Appointment_status_updated.email
@@ -1,11 +1,11 @@
-<p>Hi {!Contact_Attendance__c.Contact_Name__c},</p>
+<p>Hi {!rio_ed__Contact_Attendance__c.rio_ed__Contact_Name__c},</p>
 <p>
 One of your appointments has been updated:<br>
-Name: {!Contact_Attendance__c.Booking_Display_Name__c}<br>
-Start: {!Contact_Attendance__c.Booking_Start__c}<br>
-End: {!Contact_Attendance__c.Booking_End__c}<br>
-Status: {!Contact_Attendance__c.Booking_Status__c}
+Name: {!rio_ed__Contact_Attendance__c.rio_ed__Booking_Display_Name__c}<br>
+Start: {!rio_ed__Contact_Attendance__c.rio_ed__Booking_Start__c}<br>
+End: {!rio_ed__Contact_Attendance__c.rio_ed__Booking_End__c}<br>
+Status: {!rio_ed__Contact_Attendance__c.rio_ed__Booking_Status__c}
 </p>
 <p>
-Go here: https://YourCommunity.na124.force.com/portal/s/YourAppointmentSchedulerPage?c__apptId={!Contact_Attendance__c.BookingId__c} for more information
+Go here: https://YourCommunity.na124.force.com/portal/s/YourAppointmentSchedulerPage?c__apptId={!rio_ed__Contact_Attendance__c.rio_ed__Booking__c} for more information
 </p>

--- a/unpackaged/post/12_appointment_scheduler_automation/email/rio_ed__RIO_Education/RIO_Education_Appointment_status_updated.email-meta.xml
+++ b/unpackaged/post/12_appointment_scheduler_automation/email/rio_ed__RIO_Education/RIO_Education_Appointment_status_updated.email-meta.xml
@@ -5,15 +5,15 @@
     <name>RIO Education Appointment status updated</name>
     <style>none</style>
     <subject>Updated Appointment</subject>
-    <textOnly>Hi {!Contact_Attendance__c.Contact_Name__c},
+    <textOnly>Hi {!rio_ed__Contact_Attendance__c.rio_ed__Contact_Name__c},
 
 One of your appointments has been updated:
-Name: {!Contact_Attendance__c.Booking_Display_Name__c}
-Start: {!Contact_Attendance__c.Booking_Start__c}
-End: {!Contact_Attendance__c.Booking_End__c}
-Status: {!Contact_Attendance__c.Booking_Status__c}
+Name: {!rio_ed__Contact_Attendance__c.rio_ed__Booking_Display_Name__c}
+Start: {!rio_ed__Contact_Attendance__c.rio_ed__Booking_Start__c}
+End: {!rio_ed__Contact_Attendance__c.rio_ed__Booking_End__c}
+Status: {!rio_ed__Contact_Attendance__c.rio_ed__Booking_Status__c}
 
-Go here: https://YourCommunity.na124.force.com/portal/s/YourAppointmentSchedulerPage?c__apptId={!Contact_Attendance__c.BookingId__c} for more information</textOnly>
+Go here: https://YourCommunity.na124.force.com/portal/s/YourAppointmentSchedulerPage?c__apptId={!rio_ed__Contact_Attendance__c.rio_ed__Booking__c} for more information</textOnly>
     <type>custom</type>
     <uiType>Aloha</uiType>
 </EmailTemplate>


### PR DESCRIPTION
The namespace is stripped off when extracted out with workbench (perhaps the extraction API sees that the fields referenced object and fields that are within the instance itself and auto stripped the namespace prefix)

I have manually updated the Email template with the namespace as well as updated one of the custom field reference which had it's API name changed.



# Critical Changes

# Changes

# Issues Closed
